### PR TITLE
Create entry.client.tsx

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,0 +1,7 @@
+import { RemixBrowser } from '@remix-run/react';
+import { startTransition } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+
+startTransition(() => {
+  hydrateRoot(document.getElementById('root')!, <RemixBrowser />);
+});


### PR DESCRIPTION
import { RemixBrowser } from '@remix-run/react';
import { startTransition } from 'react';
import { hydrateRoot } from 'react-dom/client';

startTransition(() => {
  hydrateRoot(document.getElementById('root')!, <RemixBrowser />);
});

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add app/entry.client.tsx to hydrate the Remix app in the browser using React 18 (startTransition + hydrateRoot). This enables client-side bootstrapping and smoother initial render.

<sup>Written for commit 1650d2c2ec29780aef066d96fb6ef57812d69dfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

