### PR TITLE
Create entry.client.tsx

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,0 +1,7 @@
+import { RemixBrowser } from '@remix-run/react';
+import { startTransition } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+
+startTransition(() => {
+  hydrateRoot(document.getElementById('root')!, <RemixBrowser />);
+});


### PR DESCRIPTION
import { RemixBrowser } from '@remix-run/react';
import { startTransition } from 'react';
import { hydrateRoot } from 'react-dom/client';

startTransition(() => {
  hydrateRoot(document.getElementById('root')!, <RemixBrowser />);
});

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add app/entry.client.tsx to hydrate the Remix app in the browser using React 18 (startTransition + hydrateRoot). This enables client-side navigation and smoother, non-blocking hydration.

<sup>Written for commit 37a753c93e6f101c63f58a5beeee210630870185. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

